### PR TITLE
Feat/map UI

### DIFF
--- a/app/src/main/java/com/jeong/sesac/sai/recycler/comment/CommentAdapter.kt
+++ b/app/src/main/java/com/jeong/sesac/sai/recycler/comment/CommentAdapter.kt
@@ -12,12 +12,13 @@ import coil3.size.Scale
 import com.jeong.sesac.feature.model.CommentWithUser
 import com.jeong.sesac.sai.R
 import com.jeong.sesac.sai.databinding.ItemCommentBinding
+import com.jeong.sesac.sai.util.toTimeConverter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import ru.ldralighieri.corbind.view.clicks
 
 class CommentAdapter(
-    val nickname: String,
+    val userId: String,
     val lifecycleScope: LifecycleCoroutineScope ,
     val callback : (CommentWithUser, Boolean) -> Unit
 ) : ListAdapter<CommentWithUser, CommentViewHolder>(DiffComment()) {
@@ -40,10 +41,10 @@ class CommentAdapter(
             }
             tvNickname.text = comment.userInfo.nickName
             tvContent.text = comment.content
-            tvTime.text = comment.createdAt.toString()
+            tvTime.text = comment.createdAt.toTimeConverter()
 
             ivMenu.clicks().onEach {
-                val isCommentUser = comment.userInfo.nickName == nickname
+                val isCommentUser = comment.userInfo.id == userId
                 callback(comment, isCommentUser)
             }.launchIn(lifecycleScope)
         }

--- a/app/src/main/java/com/jeong/sesac/sai/recycler/libraryNote/LibraryNotesAdapter.kt
+++ b/app/src/main/java/com/jeong/sesac/sai/recycler/libraryNote/LibraryNotesAdapter.kt
@@ -6,12 +6,15 @@ import androidx.lifecycle.LifecycleCoroutineScope
 import androidx.recyclerview.widget.ListAdapter
 import coil3.load
 import coil3.request.crossfade
+import coil3.request.error
+import coil3.request.fallback
 import coil3.size.Scale
 import com.jeong.sesac.feature.model.NoteWithUser
+import com.jeong.sesac.sai.R
 import com.jeong.sesac.sai.databinding.ItemLibraryNoteBinding
-import com.jeong.sesac.sai.model.LibraryNoteUI
 import com.jeong.sesac.sai.util.throttleFirst
 import com.jeong.sesac.sai.util.throttleTime
+import com.jeong.sesac.sai.util.toTimeConverter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import ru.ldralighieri.corbind.view.clicks
@@ -31,16 +34,20 @@ ListAdapter<NoteWithUser, LibraryNoteViewHolder>(DiffLibraryNote()){
             ivProfile.load(libraryNoteList.userInfo.profile) {
                 crossfade(true)
                 scale(Scale.FILL)
+                fallback(R.drawable.ic_default_profile)
+                error(R.drawable.ic_default_profile)
             }
 
             ivImg.load(libraryNoteList.image) {
                 crossfade(true)
                 scale(Scale.FILL)
+                fallback(R.drawable.ic_default_profile)
+                error(R.drawable.ic_default_profile)
             }
             tvNickname.text = libraryNoteList.userInfo.nickName
             tvLibraryName.text = libraryNoteList.libraryName
             tvTitle.text = libraryNoteList.title
-            tvTime.text = libraryNoteList.createdAt.toString()
+            tvTime.text = libraryNoteList.createdAt.toTimeConverter()
             root.clicks().throttleFirst(throttleTime).onEach {
                 callBack(libraryNoteList)
             }.launchIn(lifecycleScope)

--- a/app/src/main/java/com/jeong/sesac/sai/ui/comment/EditCommentFragment.kt
+++ b/app/src/main/java/com/jeong/sesac/sai/ui/comment/EditCommentFragment.kt
@@ -42,7 +42,7 @@ class EditCommentFragment :
                 if (newContent.isNotEmpty()) {
                     viewLifecycleOwner.lifecycleScope.launch {
                         commentViewModel.updateComment(
-                            args.nickname,
+                            args.userId,
                             args.noteId,
                             args.commentId,
                             newContent

--- a/app/src/main/java/com/jeong/sesac/sai/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/jeong/sesac/sai/ui/home/HomeFragment.kt
@@ -34,14 +34,14 @@ import ru.ldralighieri.corbind.view.clicks
 class HomeFragment : BaseFragment<FragmentHomeBinding>(FragmentHomeBinding::inflate) {
     private lateinit var weeklyNoteAdapter: WeeklyNoteAdapter
     private lateinit var recentlyNewAdapter : NewNoteAdapter
-    private lateinit var preferenceManger: AppPreferenceManager
+    private lateinit var preference: AppPreferenceManager
     private val viewModel: NoteListViewModel by viewModels<NoteListViewModel> {
         appViewModelFactory
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        preferenceManger = AppPreferenceManager.getInstance(requireContext())
+        preference = AppPreferenceManager.getInstance(requireContext())
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
@@ -101,7 +101,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(FragmentHomeBinding::infl
 
             // 닉네임 set하는 부분
         try {
-            val nickname = preferenceManger.nickName
+            val nickname = preference.nickName
             binding.tvTitle.text = when(nickname.isEmpty()) {
                 true -> getString(R.string.login_required)
                 else -> getString(R.string.welcome_message, nickname)
@@ -111,8 +111,8 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(FragmentHomeBinding::infl
             throw Error(e.message)
         }
 
-        viewModel.getNoteList(NoteFilterType.ThisWeek(SortOrder.LATEST))
-        viewModel.getNoteList(NoteFilterType.ByLikes(false))
+        viewModel.getNoteList(NoteFilterType.ThisWeek(SortOrder.LATEST), preference.userId)
+        viewModel.getNoteList(NoteFilterType.ByLikes(false), preference.userId)
 
         viewLifecycleOwner.lifecycleScope.launch {
                 viewModel.noteListState.collectLatest { state ->

--- a/app/src/main/java/com/jeong/sesac/sai/ui/home/NewNotesLIst.kt
+++ b/app/src/main/java/com/jeong/sesac/sai/ui/home/NewNotesLIst.kt
@@ -17,6 +17,7 @@ import com.jeong.sesac.sai.databinding.ItemTabRecyclerBinding
 import com.jeong.sesac.sai.model.UiState
 import com.jeong.sesac.sai.recycler.GridDecoration
 import com.jeong.sesac.sai.recycler.newNote.NewNoteAdapter
+import com.jeong.sesac.sai.util.AppPreferenceManager
 import com.jeong.sesac.sai.util.BaseFragment
 import com.jeong.sesac.sai.viewmodel.NoteListViewModel
 import com.jeong.sesac.sai.viewmodel.factory.appViewModelFactory
@@ -27,6 +28,7 @@ class NewNotesLIst : BaseFragment<ItemTabRecyclerBinding>(ItemTabRecyclerBinding
 
     private lateinit var recentlyCreatedAdapter : NewNoteAdapter
     private val viewModel: NoteListViewModel by activityViewModels<NoteListViewModel> { appViewModelFactory }
+    private lateinit var preference: AppPreferenceManager
 
     companion object {
         fun getInstance(position: Int) =
@@ -35,6 +37,11 @@ class NewNotesLIst : BaseFragment<ItemTabRecyclerBinding>(ItemTabRecyclerBinding
                     putInt("position", position)
                 }
             }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        preference = AppPreferenceManager.getInstance(requireContext())
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
@@ -59,7 +66,7 @@ class NewNotesLIst : BaseFragment<ItemTabRecyclerBinding>(ItemTabRecyclerBinding
             1 -> NoteFilterType.ByLikes(ascending = false)
             else -> NoteFilterType.ByLikes(ascending = true)
         }
-        viewModel.getNoteList(filteredType)
+        viewModel.getNoteList(filteredType, preference.userId)
 
         viewLifecycleOwner.lifecycleScope.launch {
                 viewModel.noteListState.collectLatest { state ->

--- a/app/src/main/java/com/jeong/sesac/sai/ui/home/WeeklyNoteListFragment.kt
+++ b/app/src/main/java/com/jeong/sesac/sai/ui/home/WeeklyNoteListFragment.kt
@@ -18,6 +18,7 @@ import com.jeong.sesac.sai.databinding.ItemTabRecyclerBinding
 import com.jeong.sesac.sai.model.UiState
 import com.jeong.sesac.sai.recycler.GridDecoration
 import com.jeong.sesac.sai.recycler.weeklyNote.WeeklyNoteAdapter
+import com.jeong.sesac.sai.util.AppPreferenceManager
 import com.jeong.sesac.sai.util.BaseFragment
 import com.jeong.sesac.sai.viewmodel.NoteListViewModel
 import com.jeong.sesac.sai.viewmodel.factory.appViewModelFactory
@@ -28,6 +29,7 @@ class WeeklyNoteListFragment :
     BaseFragment<ItemTabRecyclerBinding>(ItemTabRecyclerBinding::inflate) {
     private lateinit var weeklyNoteAdapter: WeeklyNoteAdapter
     private val viewModel: NoteListViewModel by activityViewModels<NoteListViewModel> { appViewModelFactory }
+    private lateinit var preference: AppPreferenceManager
 
     companion object {
         fun getInstance(position: Int) =
@@ -36,6 +38,11 @@ class WeeklyNoteListFragment :
                     putInt("position", position)
                 }
             }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        preference = AppPreferenceManager.getInstance(requireContext())
     }
 
 
@@ -64,7 +71,7 @@ class WeeklyNoteListFragment :
             1 -> NoteFilterType.ThisWeek(SortOrder.LIKES_DESC)
             else -> NoteFilterType.ThisWeek(SortOrder.LIKES_ASC)
         }
-        viewModel.getNoteList(filteredType)
+        viewModel.getNoteList(filteredType, preference.userId)
 
         viewLifecycleOwner.lifecycleScope.launch {
                 viewModel.noteListState.collectLatest { state ->

--- a/app/src/main/java/com/jeong/sesac/sai/ui/libraryMap/writeNote/LibraryWriteNoteFragment.kt
+++ b/app/src/main/java/com/jeong/sesac/sai/ui/libraryMap/writeNote/LibraryWriteNoteFragment.kt
@@ -90,10 +90,10 @@ class LibraryWriteNoteFragment :
                 }
 
                 if (isValid) {
-                    viewModel.createNote(
+                    viewModel.createNote(preference.userId,
                         imgUri?.toString() ?: "",
                         etvTitle.text.toString(), tvNoteContent.text.toString(),
-                        args.libraryName, preference.nickName
+                        args.libraryName
                     )
 
                     viewModel.uiState.collectLatest { state ->

--- a/app/src/main/java/com/jeong/sesac/sai/ui/record/RecordListFragment.kt
+++ b/app/src/main/java/com/jeong/sesac/sai/ui/record/RecordListFragment.kt
@@ -75,7 +75,7 @@ class RecordListFragment : BaseFragment<ItemTabRecyclerBinding>(ItemTabRecyclerB
                     0 -> NoteFilterType.MyNotes
                     else -> NoteFilterType.MyLikedNotes
                 }
-                viewModel.getNoteList(filteredList, preference.nickName)
+                viewModel.getNoteList(filteredList, preference.userId)
 
                 viewModel.noteListState.collectLatest { state ->
                     when (state) {

--- a/app/src/main/java/com/jeong/sesac/sai/util/PreferenceManager.kt
+++ b/app/src/main/java/com/jeong/sesac/sai/util/PreferenceManager.kt
@@ -12,6 +12,7 @@ class AppPreferenceManager {
         private lateinit var spEditor : SharedPreferences.Editor
 
         private const val NICKNAME = "nickname"
+        private const val USER_ID = "userId"
         private const val LAST_LAT = "last_lat"
         private const val LAST_LNG = "last_lng"
 
@@ -38,6 +39,16 @@ class AppPreferenceManager {
                Log.d("닉네임 set", nickName)
                apply()
            }
+        }
+
+    var userId: String
+        get() = sp.getString(USER_ID, "").toString()
+        set(value) {
+            with(spEditor) {
+                putString(USER_ID, value)
+                Log.d("닉네임 set", nickName)
+                 apply()
+            }
         }
 
     var lastLat : Double

--- a/app/src/main/java/com/jeong/sesac/sai/viewmodel/CommentViewModel.kt
+++ b/app/src/main/java/com/jeong/sesac/sai/viewmodel/CommentViewModel.kt
@@ -24,47 +24,41 @@ class CommentViewModel(private val commentRepo: CommentRepositoryImpl) : ViewMod
     private var _commentDeleteState = MutableStateFlow<UiState<Unit>>(UiState.Loading)
     val commentDeleteState = _commentDeleteState.asStateFlow()
 
-    fun createComment(nickname: String, noteId: String, comment: Comment) {
+    fun createComment(userId: String, noteId: String, comment: Comment) {
         viewModelScope.launch {
             _commentState.value = UiState.Loading
 
-            val isSuccess = commentRepo.createComment(nickname, noteId, comment)
+            val isSuccess = commentRepo.createComment(userId, noteId, comment)
             _commentState.value =
                 if (isSuccess) {
-                    getComments(nickname, noteId)
+                    getComments(userId, noteId)
                     UiState.Success(true)
                 } else UiState.Error("다시 시도해주세요")
         }
     }
 
-    fun getComments(nickname: String, noteId: String) {
+    fun getComments(userId: String, noteId: String) {
         viewModelScope.launch {
             _commentListState.value = UiState.Loading
-
-
-            viewModelScope.launch {
-                _commentListState.value = UiState.Loading
-
-                commentRepo.getComments(nickname, noteId)
-                    .onSuccess {
-                        _commentListState.value = UiState.Success(it.reversed())
-                    }.onFailure {
-                        _commentListState.value = UiState.Error("다시 시도해주세요")
-                    }
-            }
+            commentRepo.getComments(userId, noteId)
+                .onSuccess {
+                    _commentListState.value = UiState.Success(it.reversed())
+                }.onFailure {
+                    _commentListState.value = UiState.Error("다시 시도해주세요")
+                }
 
         }
     }
 
 
-    fun updateComment(nickname: String, noteId: String, commentId: String, content: String) {
+    fun updateComment(userId: String, noteId: String, commentId: String, content: String) {
         viewModelScope.launch {
             _commentUpdateState.value = UiState.Loading
 
             commentRepo.updateComment(noteId, commentId, content)
                 .onSuccess {
                     _commentUpdateState.value = UiState.Success(Unit)
-                    getComments(nickname, noteId)
+                    getComments(userId, noteId)
                 }.onFailure {
                     _commentUpdateState.value = UiState.Error("댓글 수정에 실패했습니다")
                 }

--- a/app/src/main/java/com/jeong/sesac/sai/viewmodel/KakaoMapViewModel.kt
+++ b/app/src/main/java/com/jeong/sesac/sai/viewmodel/KakaoMapViewModel.kt
@@ -1,6 +1,5 @@
 package com.jeong.sesac.sai.viewmodel
 
-import android.content.Context
 import android.location.Location
 import android.util.Log
 import androidx.lifecycle.ViewModel
@@ -14,6 +13,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
+const val SEARCH_PERCENT = 0.9
+
 class KakaoMapViewModel(
     private val kakaoMapRepo: KakaoMapRepositoryImpl,
     private val LBSRepo: LBSRepositoryImpl
@@ -23,12 +24,54 @@ class KakaoMapViewModel(
     private var _currentLocationState = MutableStateFlow<Location?>(null)
     val currentLocationState = _currentLocationState.asStateFlow()
 
-    // 100m 내의 도서관 정보
+    // 도서관 정보
     private var _librariesInfoState = MutableStateFlow<UiState<List<PlaceInfo>>>(UiState.Loading)
     val librariesInfoState = _librariesInfoState.asStateFlow()
 
+    // 사용자의 현재 위치
+    private var lastSearchLocation: Location? = null
+
+    fun updateLocations() = viewModelScope.launch {
+        LBSRepo.findLocation().collectLatest { newLocation ->
+            _currentLocationState.value = newLocation
+
+            lastSearchLocation?.let { lastLocation ->
+                val movedDistance = calculateDistance(
+                    lastLocation.latitude, lastLocation.longitude,
+                    newLocation.latitude, newLocation.longitude
+                )
+
+                val currentSearchRadius = kakaoMapRepo.getCurrentSearchLocation()
+                val searchThreshold = currentSearchRadius * SEARCH_PERCENT
+
+                Log.d("도서관검색", """
+                현재 검색 반경: $currentSearchRadius 미터
+                이동 거리: $movedDistance 미터
+                검색 임계값: $searchThreshold 미터
+                새로운 검색 필요: ${movedDistance >= searchThreshold}
+            """.trimIndent())
+
+                Log.d("지금 위치", "$currentSearchRadius")
+
+                if(movedDistance >= searchThreshold) {
+                    Log.d("도서관검색", "검색반경을 넘었기 때문에 새로운 도서관 검색 시작")
+                    getLibrariesInfo(newLocation.longitude, newLocation.latitude)
+                    lastSearchLocation = newLocation
+
+                    Log.d("movedDistance", "사용자가 움직인 위치 :${movedDistance} ")
+                } else {
+                    updateLibraryDistances(newLocation)
+                }
+            } ?: run {
+                // lastSearchLocation이 null인 경우(처음에는 무조건 도서관 목록 검색할 수 있게)
+                getLibrariesInfo(newLocation.longitude, newLocation.latitude)
+                lastSearchLocation = newLocation
+            }
+        }
+    }
+
     /**
-     * 현재 유저의 위치에서 100m 내의 도서관 정보 받아오기
+     * 현재 유저의 위치에서 내의 도서관 정보 받아오기(100m 내에 없다면 500m씩 넓혀짐(최대 10km))
      * */
     fun getLibrariesInfo(lng: Double, lat: Double) = viewModelScope.launch {
         _librariesInfoState.value = UiState.Loading
@@ -37,7 +80,6 @@ class KakaoMapViewModel(
             .fold(
                 onSuccess = { libraries ->
                     _librariesInfoState.value = UiState.Success(libraries)
-
                 },
                 onFailure = { e ->
                     _librariesInfoState.value = UiState.Error(e.message ?: "알수 없는 에러 발생")
@@ -46,14 +88,26 @@ class KakaoMapViewModel(
             )
     }
 
-    fun getCurrentLocation() = viewModelScope.launch {
-        LBSRepo.findLocation().collectLatest { location ->
-            _currentLocationState.value = location
+    fun updateLibraryDistances(newLocation: Location) {
+        val currentLibraries = (_librariesInfoState.value as UiState.Success).data
 
-            getLibrariesInfo(location.longitude, location.latitude)
+        val updatedLibraries = currentLibraries.map { library ->
+            val newDistance = calculateDistance(
+                newLocation.latitude, newLocation.longitude,
+                library.lat.toDouble(), library.lng.toDouble())
+            library.copy(distance = newDistance.toString())
         }
+        _librariesInfoState.value = UiState.Success(updatedLibraries)
     }
 
+}
 
-
+// 현재 위치에서 얼만큼 거리가 차이나는지 계산하는 함수
+private fun calculateDistance(
+    currentLat: Double, currentLng: Double,
+    clickedLat: Double, clickedLng: Double
+): Float {
+    val result = FloatArray(1)
+    Location.distanceBetween(currentLat, currentLng, clickedLat, clickedLng, result)
+    return result[0]
 }

--- a/app/src/main/java/com/jeong/sesac/sai/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/jeong/sesac/sai/viewmodel/LoginViewModel.kt
@@ -10,26 +10,31 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 class LoginViewModel(private val loginRepo: LoginRepositoryImpl) : ViewModel() {
-    private var _duplicateState = MutableStateFlow<UiState<String>>(UiState.Loading)
+    private var _duplicateState = MutableStateFlow<UiState<Boolean>>(UiState.Loading)
     val duplicateState get() = _duplicateState.asStateFlow()
 
     private val _userCreateState = MutableStateFlow<UiState<String>>(UiState.Loading)
     val userCreateState = _userCreateState.asStateFlow()
 
     @SuppressLint("NewApi")
-    fun serUserInfo(nickname: String) = viewModelScope.launch {
+    fun setUserInfo(nickname: String) = viewModelScope.launch {
         _userCreateState.value = UiState.Loading
-        val isSuccess = loginRepo.setUser(nickname)
-        _userCreateState.value =
-            if (isSuccess) UiState.Success(nickname) else UiState.Error("다시 시도해주세요")
+        loginRepo.setUser(nickname)
+            .onSuccess {
+                _userCreateState.value = UiState.Success(it)
+            }.onFailure {
+                UiState.Error("다시 시도해주세요")
+            }
     }
 
     fun checkDuplicatedNickname(nickname: String) = viewModelScope.launch {
         _duplicateState.value = UiState.Loading
-        val isSuccess = loginRepo.checkDuplicateNickname(nickname)
-        _duplicateState.value =
-            if (isSuccess) UiState.Success(nickname) else UiState.Error("다시 시도해주세요")
+        loginRepo.checkDuplicateNickname(nickname)
+            .onSuccess {
+                _duplicateState.value = UiState.Success(it)
+            }.onFailure {
+                _duplicateState.value = UiState.Error("다시 시도해주세요")
+            }
     }
-
 }
 

--- a/app/src/main/java/com/jeong/sesac/sai/viewmodel/NoteListViewModel.kt
+++ b/app/src/main/java/com/jeong/sesac/sai/viewmodel/NoteListViewModel.kt
@@ -1,6 +1,5 @@
 package com.jeong.sesac.sai.viewmodel
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.jeong.sesac.data.repository.NoteListRepositoryImpl
@@ -28,10 +27,10 @@ class NoteListViewModel(private val noteListRepo: NoteListRepositoryImpl) : View
     /**
      * 노트 리스트를 가져오기(전체)
      */
-    fun getNoteList(filterType: NoteFilterType, nickname: String? = null) = viewModelScope.launch {
+    fun getNoteList(filterType: NoteFilterType, userId: String) = viewModelScope.launch {
         _noteListState.value = UiState.Loading
 
-        noteListRepo.getNoteList(filterType, nickname)
+        noteListRepo.getNoteList(filterType, userId)
             .onSuccess { notes ->
                 _noteListState.value = UiState.Success(notes)
             }.onFailure { error ->

--- a/app/src/main/java/com/jeong/sesac/sai/viewmodel/NoteViewModel.kt
+++ b/app/src/main/java/com/jeong/sesac/sai/viewmodel/NoteViewModel.kt
@@ -32,10 +32,16 @@ class NoteViewModel(
     val fetchNoteState = _fetchNoteState.asStateFlow()
 
     @RequiresApi(Build.VERSION_CODES.O)
-    fun createNote(imgUri: String, title: String, content: String, libraryName: String, nickname: String) {
+    fun createNote(
+        userId: String,
+        imgUri: String,
+        title: String,
+        content: String,
+        libraryName: String
+    ) {
         val note = Note(
             id = "",
-            userId = "",
+            userId = userId,
             image = imgUri,
             title = title,
             content = content,
@@ -47,10 +53,12 @@ class NoteViewModel(
         viewModelScope.launch {
             _uiState.value = UiState.Loading
 
-            val isSuccess = noteRepo.createNote(note, nickname)
-            _uiState.value =
-                if (isSuccess) UiState.Success(isSuccess) else UiState.Error("다시 시도해주세요")
-
+            noteRepo.createNote(note)
+                .onSuccess {
+                    _uiState.value = UiState.Success(it)
+                }.onFailure {
+                    _uiState.value = UiState.Error("다시시도해주세요")
+                }
         }
     }
 
@@ -71,11 +79,10 @@ class NoteViewModel(
      * 쪽지 업데이트
      * */
     fun updateNote(noteId: String, note: Note) = viewModelScope.launch {
-
         _fetchNoteState.value = UiState.Loading
 
         noteRepo.updateNote(noteId, note)
-            .onSuccess {
+            .onSuccess { note ->
                 _fetchNoteState.value = UiState.Success(Unit)
             }.onFailure {
                 _fetchNoteState.value = UiState.Error("쪽지 업데이트 실패")

--- a/app/src/main/res/layout/fragment_library_note_detail.xml
+++ b/app/src/main/res/layout/fragment_library_note_detail.xml
@@ -18,6 +18,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="삭제"
+            android:visibility="invisible"
             android:clickable="true"
             android:focusable="true"
             android:layout_gravity="end"
@@ -30,6 +31,7 @@
             android:textStyle="bold"
             android:clickable="true"
             android:focusable="true"
+            android:visibility="invisible"
             android:layout_gravity="end"
             android:layout_marginEnd="12dp"
             />

--- a/app/src/main/res/navigation/navigation_graph.xml
+++ b/app/src/main/res/navigation/navigation_graph.xml
@@ -198,7 +198,7 @@
                 android:name="noteId"
                 app:argType="string" />
             <argument
-                android:name="nickname"
+                android:name="userId"
                 app:argType="string" />
             <argument
                 android:name="commentId"
@@ -234,7 +234,7 @@
             android:name="noteId"
             app:argType="string" />
         <argument
-            android:name="nickname"
+            android:name="userId"
             app:argType="string" />
         <argument
             android:name="commentId"

--- a/data/src/main/java/com/jeong/sesac/data/datasource/CommentFirebaseDataSource.kt
+++ b/data/src/main/java/com/jeong/sesac/data/datasource/CommentFirebaseDataSource.kt
@@ -4,8 +4,8 @@ import com.jeong.sesac.feature.model.Comment
 import com.jeong.sesac.feature.model.CommentWithUser
 
 interface CommentFirebaseDataSource {
-    suspend fun createComment(nickname: String, noteId: String, comment: Comment): Boolean
-    suspend fun getComments(nickname: String, noteId: String): Result<List<CommentWithUser>>
+    suspend fun createComment(userId: String, noteId: String, comment: Comment): Boolean
+    suspend fun getComments(userId: String, noteId: String): Result<List<CommentWithUser>>
     suspend fun updateComment(noteId: String, commentId: String, content: String) : Result<Unit>
     suspend fun deleteComment(noteId: String, commentId: String): Result<Unit>
 }

--- a/data/src/main/java/com/jeong/sesac/data/datasource/FireBaseDataSource.kt
+++ b/data/src/main/java/com/jeong/sesac/data/datasource/FireBaseDataSource.kt
@@ -7,10 +7,10 @@ import com.jeong.sesac.feature.model.UserInfo
 
 
 interface FireBaseDataSource {
-      suspend fun createUser(userInfo: User) : Boolean
-      suspend fun getDuplicateNickname(nickname : String) : Boolean
-      suspend fun createNote(note : Note, nickname: String) : Boolean
-      suspend fun getNoteList(): List<Note>
+      suspend fun createUser(userInfo: User) : Result<String>
+      suspend fun getDuplicateNickname(nickname : String): Result<Boolean>
+      suspend fun createNote(note : Note): Result<Boolean>
+      suspend fun getNoteList(): Result<List<Note>>
       suspend fun getUserInfo(userId: String): UserInfo?
       suspend fun getIdByNickname(nickname: String): String?
       suspend fun getMyLikedNotes(userId: String): List<String>

--- a/data/src/main/java/com/jeong/sesac/data/datasource/KakaoMapDataSourceImpl.kt
+++ b/data/src/main/java/com/jeong/sesac/data/datasource/KakaoMapDataSourceImpl.kt
@@ -5,29 +5,40 @@ import com.jeong.sesac.data.api.service.KakaoMapService
 import com.jeong.sesac.data.dto.toMap
 import com.jeong.sesac.feature.model.PlaceInfo
 
+const val INITIAL_SEARCH_RADIUS = 300
+const val RADIUS_INCREMENT = 500
+
 class KakaoMapDataSourceImpl(private val kakaoService: KakaoMapService) : KakaoMapDataSource {
+    var lastSearchRadius = INITIAL_SEARCH_RADIUS
+
     override suspend fun getLibraryInfo(lng: Double, lat: Double): Result<List<PlaceInfo>> {
-        var currentRadius = 0
+        var currentRadius = INITIAL_SEARCH_RADIUS
+        Log.d("datasource", "처음 currentRadius: ${currentRadius}")
+
         return runCatching {
-            var response = kakaoService.getLibraryInfo(x = lng, y = lat, radius = currentRadius + 100)
+            var response = kakaoService.getLibraryInfo(x = lng, y = lat, radius = currentRadius)
 
-            Log.d("DataSource", "Response Code: ${response.code()}, response body : ${response.body()}")
+            Log.d(
+                "DataSource",
+                "Response Code: ${response.code()}, response body : ${response.body()}"
+            )
 
-            while(response.isSuccessful && response.body()!!.documents.isEmpty()) {
-                currentRadius += 500
-                Log.d("datasource", "currentRadius: ${currentRadius}")
+            while (response.isSuccessful && response.body()!!.documents.isEmpty()) {
+                currentRadius += RADIUS_INCREMENT
 
                 response = kakaoService.getLibraryInfo(x = lng, y = lat, radius = currentRadius)
             }
 
-
             if (response.isSuccessful && response.body() != null) {
+                lastSearchRadius = currentRadius
                 Log.d("DataSource", "Success: ${response.body()}")
-                currentRadius = 0
-                response.body()!!.documents.map { it.toMap() }
+                Log.d("datasource", "도서관 검색 범위: ${currentRadius}")
+                response.body()!!.documents.map { it.toMap(currentRadius) }
             } else {
                 throw Exception("도서관정보 가져오기 실패: ${response.errorBody()?.string()}")
             }
         }
     }
+
+    fun getCurrentSearchRadius() = lastSearchRadius
 }

--- a/data/src/main/java/com/jeong/sesac/data/dto/KakaoMapInfo.kt
+++ b/data/src/main/java/com/jeong/sesac/data/dto/KakaoMapInfo.kt
@@ -20,10 +20,10 @@ data class Place(
     val place_url: String,
     val x: String,
     val y: String,
-    val distance: String
+    val distance: String,
 )
 
-fun Place.toMap(): PlaceInfo {
+fun Place.toMap(searchRadius: Int): PlaceInfo {
         return PlaceInfo(
             id = id,
             place = place_name,
@@ -32,6 +32,7 @@ fun Place.toMap(): PlaceInfo {
             lat = y,
             lng = x,
             placeURL = place_url,
-            distance = distance
+            distance = distance,
+            searchRadius = searchRadius
         )
     }

--- a/data/src/main/java/com/jeong/sesac/data/repository/CommentRepositoryImpl.kt
+++ b/data/src/main/java/com/jeong/sesac/data/repository/CommentRepositoryImpl.kt
@@ -8,21 +8,21 @@ import java.util.Date
 
 class CommentRepositoryImpl(private val commentDataSource: CommentFirebaseDataSourceImpl) : ICommentRepository {
 
-    override suspend fun createComment(nickname: String, noteId: String, comment: Comment):
+    override suspend fun createComment(userId: String, noteId: String, comment: Comment):
             Boolean {
         val userComment = Comment(
             id = "",
-            userId = "",
+            userId = userId,
             noteId = noteId,
             content = comment.content,
             createdAt = System.currentTimeMillis()
         )
 
-        return commentDataSource.createComment(nickname, noteId, userComment)
+        return commentDataSource.createComment(userId, noteId, userComment)
     }
 
-    override suspend fun getComments(nickname: String, noteId: String): Result<List<CommentWithUser>> {
-        return commentDataSource.getComments(nickname, noteId)
+    override suspend fun getComments(userId: String, noteId: String): Result<List<CommentWithUser>> {
+        return commentDataSource.getComments(userId, noteId)
     }
 
     override suspend fun updateComment(noteId: String, commentId: String, content: String): Result<Unit> {

--- a/data/src/main/java/com/jeong/sesac/data/repository/KakaoMapRepositoryImpl.kt
+++ b/data/src/main/java/com/jeong/sesac/data/repository/KakaoMapRepositoryImpl.kt
@@ -7,4 +7,7 @@ import com.jeong.sesac.feature.repository.IKakaoMapRepository
 
 class KakaoMapRepositoryImpl(private val kakakoMapDatasource : KakaoMapDataSourceImpl) : IKakaoMapRepository {
     override suspend fun getLibraryInfo(lng: Double, lat: Double): Result<List<PlaceInfo>> = kakakoMapDatasource.getLibraryInfo(lng, lat)
+    override fun getCurrentSearchLocation(): Int {
+        return kakakoMapDatasource.getCurrentSearchRadius()
+    }
 }

--- a/data/src/main/java/com/jeong/sesac/data/repository/LBSRepositoryImpl.kt
+++ b/data/src/main/java/com/jeong/sesac/data/repository/LBSRepositoryImpl.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Looper
+import android.util.Log
 import androidx.core.content.ContextCompat
 import com.google.android.gms.location.LocationCallback
 import com.google.android.gms.location.LocationRequest
@@ -21,12 +22,12 @@ class LBSRepositoryImpl(private val context: Context) {
      * */
     fun findLocation() = callbackFlow {
         val locationRequest = LocationRequest.Builder(
-            Priority.PRIORITY_HIGH_ACCURACY, 6000L
+            Priority.PRIORITY_HIGH_ACCURACY, 10000L
         ).run {
-            setMinUpdateDistanceMeters(2F)
+            setMinUpdateDistanceMeters(10F)
             setWaitForAccurateLocation(true)
-//            setMinUpdateIntervalMillis(6000L)
-//            setMaxUpdateDelayMillis(6000L)
+//            setMinUpdateIntervalMillis(10000L)
+//            setMaxUpdateDelayMillis(12000L)
                 .build()
         }
 
@@ -34,6 +35,7 @@ class LBSRepositoryImpl(private val context: Context) {
         val locationCallback = object : LocationCallback() {
             override fun onLocationResult(locationResult: LocationResult) {
                 locationResult.lastLocation?.let { location ->
+                    Log.d("현재 경도위도", "현재경도위도: lat=${location.latitude}, lng=${location.longitude}")
                     trySend(location)
                 }
             }
@@ -50,17 +52,8 @@ class LBSRepositoryImpl(private val context: Context) {
                 Looper.getMainLooper()
             )
         }
-        currentFusedLocationClient.requestLocationUpdates(
-            locationRequest,
-            locationCallback,
-            Looper.getMainLooper()
-        )
-
         awaitClose {
             currentFusedLocationClient.removeLocationUpdates(locationCallback)
         }
     }
-
-
-
 }

--- a/data/src/main/java/com/jeong/sesac/data/repository/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/jeong/sesac/data/repository/LoginRepositoryImpl.kt
@@ -7,11 +7,7 @@ import com.jeong.sesac.feature.repository.ILoginRepository
 
 class LoginRepositoryImpl(private val fireStoreImpl: FireBaseDataSourceImpl) : ILoginRepository {
 
-    override suspend fun getUser(id: String) {
-        TODO("파베에서 id받아서 가져오기")
-    }
-
-    override suspend fun setUser(nickname: String) : Boolean {
+    override suspend fun setUser(nickname: String): Result<String> {
 
         val userInfo = User(
             id = "",
@@ -25,7 +21,7 @@ class LoginRepositoryImpl(private val fireStoreImpl: FireBaseDataSourceImpl) : I
     }
 
 
-    override suspend fun checkDuplicateNickname(nickname: String): Boolean {
+    override suspend fun checkDuplicateNickname(nickname: String): Result<Boolean> {
         return fireStoreImpl.getDuplicateNickname(nickname)
     }
 }

--- a/data/src/main/java/com/jeong/sesac/data/repository/NoteListRepositoryImpl.kt
+++ b/data/src/main/java/com/jeong/sesac/data/repository/NoteListRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.jeong.sesac.data.repository
 
+import android.util.Log
 import com.jeong.sesac.data.datasource.FireBaseDataSourceImpl
 import com.jeong.sesac.domain.model.NoteFilterType
 import com.jeong.sesac.domain.model.SortOrder
@@ -10,93 +11,87 @@ class NoteListRepositoryImpl(private val fireBaseDataSource: FireBaseDataSourceI
     INoteListRepository {
     override suspend fun getNoteList(
         filterType: NoteFilterType,
-        nickname: String?
+        userId: String
     ): Result<List<NoteWithUser>> {
-        return try {
-            // 전체 노트 리스트 가져오기
-            val noteList = fireBaseDataSource.getNoteList()
+        return fireBaseDataSource.getNoteList().fold(
+            onSuccess = { noteList ->
+                // 필터 타입에 따라 노트 리스트 필터링 및 정렬
+                val filteredNoteList = when (filterType) {
+                    is NoteFilterType.ThisWeek -> {
+                        val weekAgo = System.currentTimeMillis() - 7 * 24 * 60 * 60 * 1000
+                        val thisWeekNotes = noteList.filter {
+                            it.createdAt > weekAgo
+                        }
 
-            val userId = when (filterType) {
-                is NoteFilterType.MyNotes, is NoteFilterType.MyLikedNotes -> {
-                    nickname?.let { fireBaseDataSource.getIdByNickname(it) }
-                }
-
-                else -> null
-            }
-
-            // 타입에 따라서 쪽지리스트 필터링
-            val filteredNoteList = when (filterType) {
-                is NoteFilterType.ThisWeek -> {
-                    val weekAgo = System.currentTimeMillis() - 7 * 24 * 60 * 60 * 1000
-                    val thisWeekNotes = noteList.filter {
-                        it.createdAt > weekAgo
+                        when (filterType.sortOrder) {
+                            SortOrder.LATEST -> thisWeekNotes.sortedByDescending { it.createdAt }
+                            SortOrder.LIKES_DESC -> thisWeekNotes.sortedByDescending { it.likes }
+                            SortOrder.LIKES_ASC -> thisWeekNotes.sortedBy { it.likes }
+                        }
                     }
 
-                    when (filterType.sortOrder) {
-                        SortOrder.LATEST -> thisWeekNotes.sortedByDescending { it.createdAt }
-                        SortOrder.LIKES_DESC -> thisWeekNotes.sortedByDescending { it.likes }
-                        SortOrder.LIKES_ASC -> thisWeekNotes.sortedBy { it.likes }
+                    is NoteFilterType.ByCreatedAt -> {
+                        if (filterType.ascending) {
+                            noteList.sortedBy { it.createdAt }
+                        } else {
+                            noteList.sortedByDescending { it.createdAt }
+                        }
                     }
-                }
 
-                is NoteFilterType.ByCreatedAt -> {
-                    if (filterType.ascending) {
-                        noteList.sortedBy { it.createdAt }
-                    } else {
+                    is NoteFilterType.ByLikes -> {
+                        if (filterType.ascending) {
+                            noteList.sortedBy { it.likes }
+                        } else {
+                            noteList.sortedByDescending { it.likes }
+                        }
+                    }
+
+                    is NoteFilterType.ByLibrary -> {
+                        noteList.filter { it.libraryName == filterType.libraryName }
+                    }
+
+                    is NoteFilterType.AllLibrary -> {
                         noteList.sortedByDescending { it.createdAt }
                     }
-                }
 
-                is NoteFilterType.ByLikes -> {
-                    if (filterType.ascending) {
-                        noteList.sortedBy { it.likes }
-                    } else {
-                        noteList.sortedByDescending { it.likes }
+                    is NoteFilterType.MyNotes -> {
+                        noteList.filter { it.userId == userId }
+                            .sortedByDescending { it.createdAt }
+                    }
+
+                    is NoteFilterType.MyLikedNotes -> {
+                        val likedNoteIdList = fireBaseDataSource.getMyLikedNotes(userId)
+                        noteList.filter { it.id in likedNoteIdList }
+                            .sortedByDescending { it.createdAt }
                     }
                 }
 
-                is NoteFilterType.ByLibrary -> {
-                    noteList.filter { it.libraryName == filterType.libraryName }
+                // 필터링된 노트에 사용자 정보 추가
+                val notesWithUser = filteredNoteList.map { note ->
+                    val userInfo = fireBaseDataSource.getUserInfo(userId)
+                    NoteWithUser(
+                        id = note.id,
+                        userInfo = userInfo,
+                        image = note.image,
+                        title = note.title,
+                        createdAt = note.createdAt,
+                        libraryName = note.libraryName,
+                        content = note.content,
+                        likes = note.likes
+                    )
                 }
-
-                is NoteFilterType.AllLibrary -> {
-                    noteList.sortedByDescending { it.createdAt }
-                }
-
-                is NoteFilterType.MyNotes -> {
-                    noteList.filter { it.userId == userId }.sortedByDescending { it.createdAt }
-                }
-
-                is NoteFilterType.MyLikedNotes -> {
-                    val likedNoteIdList = fireBaseDataSource.getMyLikedNotes(userId!!)
-                    noteList.filter { it.id in likedNoteIdList }.sortedByDescending { it.createdAt }
-                }
+                Result.success(notesWithUser)
+            },
+            onFailure = { error ->
+                Log.e("NoteListRepository", "error getNoteList: ${error.message}")
+                Result.failure(error)
             }
-
-            val notesWithUser = filteredNoteList.map { note ->
-                val userInfo = fireBaseDataSource.getUserInfo(note.userId)
-                NoteWithUser(
-                    id = note.id,
-                    userInfo = userInfo,
-                    image = note.image,
-                    title = note.title,
-                    createdAt = note.createdAt,
-                    libraryName = note.libraryName,
-                    content = note.content,
-                    likes = note.likes
-                )
-            }
-
-            Result.success(notesWithUser)
-        } catch (e: Exception) {
-            Result.failure(e)
-        }
+        )
     }
 
     suspend fun getLibraryNotes(libraryName: String): Result<List<NoteWithUser>> {
         return fireBaseDataSource.getLibraryNotes(libraryName)
     }
-
 }
 
 

--- a/data/src/main/java/com/jeong/sesac/data/repository/NoteRepositoryImpl.kt
+++ b/data/src/main/java/com/jeong/sesac/data/repository/NoteRepositoryImpl.kt
@@ -7,10 +7,10 @@ import com.jeong.sesac.feature.model.NoteWithUser
 
 class NoteRepositoryImpl(private val fireBaseDataSource: FireBaseDataSource) : INoteRepository {
 
-    override suspend fun createNote(note: Note, nickname: String): Boolean {
+    override suspend fun createNote(note: Note): Result<Boolean>{
         val noteInfo = Note(
             id = "",
-            userId = "",
+            userId = note.userId,
             image = note.image,
             title = note.title,
             content = note.content,
@@ -19,7 +19,7 @@ class NoteRepositoryImpl(private val fireBaseDataSource: FireBaseDataSource) : I
             likes = 0,
             )
 
-        return fireBaseDataSource.createNote(noteInfo, nickname)
+        return fireBaseDataSource.createNote(noteInfo)
     }
 
     suspend fun updateNote(noteId: String, note: Note): Result<Unit> {

--- a/feature/src/main/java/com/jeong/sesac/domain/model/LibraryNote.kt
+++ b/feature/src/main/java/com/jeong/sesac/domain/model/LibraryNote.kt
@@ -19,7 +19,8 @@ data class PlaceInfo(
     val placeURL: String,
     val lat: String,
     val lng: String,
-    val distance: String
+    val distance: String,
+    val searchRadius: Int
 )
 
 data class Note(
@@ -51,10 +52,10 @@ data class UserInfo (
 )
 
 data class Comment(
-    val id: String,
-    val userId: String,
-    val noteId: String,
-    val content: String,
+    val id: String = "",
+    val userId: String = "",
+    val noteId: String = "",
+    val content: String ="",
     val createdAt: Long = System.currentTimeMillis()
 )
 

--- a/feature/src/main/java/com/jeong/sesac/domain/repository/ICommentRepository.kt
+++ b/feature/src/main/java/com/jeong/sesac/domain/repository/ICommentRepository.kt
@@ -4,8 +4,8 @@ import com.jeong.sesac.feature.model.Comment
 import com.jeong.sesac.feature.model.CommentWithUser
 
 interface ICommentRepository {
-    suspend fun createComment(nickname: String, noteId: String, comment: Comment): Boolean
-    suspend fun getComments(nickname: String, noteId: String): Result<List<CommentWithUser>>
+    suspend fun createComment(userId: String, noteId: String, comment: Comment): Boolean
+    suspend fun getComments(userId: String, noteId: String): Result<List<CommentWithUser>>
     suspend fun updateComment(noteId: String, commentId: String, content: String): Result<Unit>
     suspend fun deleteComment(noteId: String, commentId: String): Result<Unit>
 }

--- a/feature/src/main/java/com/jeong/sesac/domain/repository/IKakaoMapRepository.kt
+++ b/feature/src/main/java/com/jeong/sesac/domain/repository/IKakaoMapRepository.kt
@@ -4,4 +4,5 @@ import com.jeong.sesac.feature.model.PlaceInfo
 
 interface IKakaoMapRepository {
     suspend fun getLibraryInfo(lng: Double, lat: Double) : Result<List<PlaceInfo>>
+    fun getCurrentSearchLocation(): Int
 }

--- a/feature/src/main/java/com/jeong/sesac/domain/repository/ILoginRepository.kt
+++ b/feature/src/main/java/com/jeong/sesac/domain/repository/ILoginRepository.kt
@@ -2,7 +2,6 @@ package com.jeong.sesac.feature.repository
 
 
 interface ILoginRepository {
-    suspend fun getUser(id : String)
-    suspend fun setUser(nickname: String) : Boolean
-    suspend fun checkDuplicateNickname(nickname : String) : Boolean
+    suspend fun setUser(nickname: String): Result<String>
+    suspend fun checkDuplicateNickname(nickname : String): Result<Boolean>
 }

--- a/feature/src/main/java/com/jeong/sesac/domain/repository/INoteListRepository.kt
+++ b/feature/src/main/java/com/jeong/sesac/domain/repository/INoteListRepository.kt
@@ -4,5 +4,5 @@ import com.jeong.sesac.domain.model.NoteFilterType
 import com.jeong.sesac.feature.model.NoteWithUser
 
 interface INoteListRepository {
-    suspend fun getNoteList(filterType: NoteFilterType, nickname: String? = null): Result<List<NoteWithUser>>
+    suspend fun getNoteList(filterType: NoteFilterType, userId: String): Result<List<NoteWithUser>>
 }

--- a/feature/src/main/java/com/jeong/sesac/domain/repository/INoteRepository.kt
+++ b/feature/src/main/java/com/jeong/sesac/domain/repository/INoteRepository.kt
@@ -3,5 +3,5 @@ package com.jeong.sesac.domain.repository
 import com.jeong.sesac.feature.model.Note
 
 interface INoteRepository{
-    suspend fun createNote(note: Note, nickname: String): Boolean
+    suspend fun createNote(note: Note): Result<Boolean>
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,10 +11,10 @@ material = "1.12.0"
 activity = "1.10.0"
 constraintlayout = "2.2.0"
 lifecycleViewmodelKtx = "2.8.7"
-fragmentKtx = "1.8.5"
-navigationFragmentKtx = "2.8.5"
-navigationUiKtx = "2.8.5"
-navigationSafeArgs = "2.8.5"
+fragmentKtx = "1.8.6"
+navigationFragmentKtx = "2.8.7"
+navigationUiKtx = "2.8.7"
+navigationSafeArgs = "2.8.7"
 androidx-lifecycle-viewmodel-ktx = "2.8.7"
 ru-ldralighieri-corbind = "1.11.0"
 ru-ldralighieri-corbind-material = "1.11.0"
@@ -25,13 +25,13 @@ retrofit = "2.11.0"
 jetbrainsKotlinJvm = "2.1.0"
 googleServices = "4.4.2"
 playServicesLocation = "21.3.0"
-firebaseFirestoreKtx = "25.1.1"
-firebaseBom = "33.8.0"
+firebaseFirestoreKtx = "25.1.2"
+firebaseBom = "33.9.0"
 kakaoMaps = "2.12.8"
 kakaoSdk = "2.20.6"
 datastore-preference = "1.1.2"
 tedpermissionNormal = "3.4.2"
-uiAndroid = "1.7.6"
+uiAndroid = "1.7.8"
 places = "4.1.0"
 firebaseStorageKtx = "21.0.1"
 firebaseCommonKtx = "21.0.0"
@@ -50,6 +50,7 @@ androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifec
 androidx-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragmentKtx" }
 androidx-navigation-fragment-ktx = { group = "androidx.navigation", name = "navigation-fragment-ktx", version.ref = "navigationFragmentKtx" }
 androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "navigationUiKtx" }
+
 moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshiKotlin" }
 ru-ldralighieri-corbind = { module = "ru.ldralighieri.corbind:corbind", version.ref = "ru-ldralighieri-corbind" }
 ru-ldralighieri-corbind-material = { module = "ru.ldralighieri.corbind:corbind-material", version.ref = "ru-ldralighieri-corbind-material" }
@@ -65,10 +66,10 @@ corbind-appcompat = { group = "ru.ldralighieri.corbind", name = "corbind-appcomp
 corbind-activity = { group = "ru.ldralighieri.corbind", name = "corbind-activity", version.ref = "ru-ldralighieri-corbind" }
 datastore-preference = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore-preference" }
 play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
-androidx-ui-android = { group = "androidx.compose.ui", name = "ui-android", version.ref = "uiAndroid" }
 places = { group = "com.google.android.libraries.places", name = "places", version.ref = "places" }
 tedpermission-normal = { module = "io.github.ParkSangGwon:tedpermission-normal", version.ref = "tedpermissionNormal" }
 firebase-storage-ktx = { group = "com.google.firebase", name = "firebase-storage-ktx", version.ref = "firebaseStorageKtx" }
+androidx-ui-android = { group = "androidx.compose.ui", name = "ui-android", version.ref = "uiAndroid" }
 firebase-common-ktx = { group = "com.google.firebase", name = "firebase-common-ktx", version.ref = "firebaseCommonKtx" }
 
 [plugins]


### PR DESCRIPTION
1. map 수정
- map에서 도서관 정보에 따라 label을 보여줌
-> 이 때 계속 일정한 초마다 새로 도서관 정보를 요청함
-> 이 부분을 검색 반경을 넘지 않으면 재요청하지 않도록 함

- 폴리곤을 추가
-> 유저가 현재 위치와 도서관까지 거리가(상호작용거리) 100m이하면 label과 polygon의 색깔을 변경시키고,
해당 도서관의 쪽지와 서평을 볼 수 있도록 함

- 지금 현재 위치에서 가장 가까운 도서관과 몇 m 차이나는지도 계속 textView를 통해서 유저에게 알려줌

2. 쪽지 및 코멘트 update, delete 수정
해당 유저가 쓴 글이 아님에도 수정, 삭제가 되는 부분을 수정함

3. 유저아이디 저장 부분
2번에서 유저의 아이디 값을 nickname으로 조회하여 가져옴
그런데 빈 값으로 나옴 -> 유저의 현재 일단은 회원가입시 유저 아이디를 preference에 저장하는 것으로 변경함

4. 시간 표시 수정
Long의 확장함수로 toTimeConverter() 함수를 만들어서 현재 시간에서 호출한 long 값을 빼서 5,10,20,30,1시간 이런 식으로 화면에 보여지게 함